### PR TITLE
update to newer version of ndk toolchain

### DIFF
--- a/libflush/config-arm.mk
+++ b/libflush/config-arm.mk
@@ -1,9 +1,9 @@
 # Define Android specific variables
 ANDROID_NDK_PATH = /opt/android-ndk
-ANDROID_TOOLCHAIN_BIN = ${ANDROID_NDK_PATH}/toolchains/arm-linux-androideabi-4.9/prebuilt/linux-x86_64/bin
-ANDROID_SYSROOT = ${ANDROID_NDK_PATH}/platforms/${ANDROID_PLATFORM}/arch-arm
+ANDROID_TOOLCHAIN_BIN = ${ANDROID_NDK_PATH}/toolchains/llvm/prebuilt/linux-x86_64/bin
+ANDROID_SYSROOT = ${ANDROID_NDK_PATH}/toolchains/llvm/prebuilt/linux-x86_64/sysroot
 
-ANDROID_CC = ${ANDROID_TOOLCHAIN_BIN}/arm-linux-androideabi-gcc
+ANDROID_CC = ${ANDROID_TOOLCHAIN_BIN}/armv7a-linux-androideabi21-clang
 ANDROID_CC_FLAGS = --sysroot=${ANDROID_SYSROOT}
 
 ANDROID_INCLUDES = -I ${ANDROID_NDK_PATH}/platforms/${ANDROID_PLATFORM}/arch-arm/usr/include

--- a/libflush/config-arm64.mk
+++ b/libflush/config-arm64.mk
@@ -1,9 +1,9 @@
 # Define Android specific variables
 ANDROID_NDK_PATH = /opt/android-ndk
-ANDROID_TOOLCHAIN_BIN = ${ANDROID_NDK_PATH}/toolchains/aarch64-linux-android-4.9/prebuilt/linux-x86_64/bin
-ANDROID_SYSROOT = ${ANDROID_NDK_PATH}/platforms/${ANDROID_PLATFORM}/arch-arm64
+ANDROID_TOOLCHAIN_BIN = ${ANDROID_NDK_PATH}/toolchains/llvm/prebuilt/linux-x86_64/bin
+ANDROID_SYSROOT = ${ANDROID_NDK_PATH}/toolchains/llvm/prebuilt/linux-x86_64/sysroot
 
-ANDROID_CC = ${ANDROID_TOOLCHAIN_BIN}/aarch64-linux-android-gcc
+ANDROID_CC = ${ANDROID_TOOLCHAIN_BIN}/aarch64-linux-android21-clang
 ANDROID_CC_FLAGS = --sysroot=${ANDROID_SYSROOT}
 
 ANDROID_INCLUDES = -I ${ANDROID_NDK_PATH}/platforms/${ANDROID_PLATFORM}/arch-arm64/usr/include


### PR DESCRIPTION
According to [this](https://stackoverflow.com/questions/54785091/whats-the-use-of-llvm-in-android-ndk-toolchains), the new ndk uses llvm as backend. 